### PR TITLE
Use stdin instead of tmp file for goimports input

### DIFF
--- a/GoImports.sublime-settings
+++ b/GoImports.sublime-settings
@@ -3,11 +3,5 @@
   "goimports_bin": "/usr/local/bin/goimports",
 
   // enable/disable plugin
-  "goimports_enabled": true,
-
-  // Use tabs to format the source (default: false)
-  "use_tabs": false,
-
-  // Tab width (default: 4)
-  "tab_width": 4
+  "goimports_enabled": true
 }


### PR DESCRIPTION
Also removed the tab settings that are now longer available in goimports.

Fixes #2