### PR TITLE
fix imports of 3rd party code

### DIFF
--- a/GoImports.py
+++ b/GoImports.py
@@ -54,8 +54,9 @@ class GoimportsrunCommand(sublime_plugin.TextCommand):
 
         try:
             # Run the 'goimports' command
+            cur_dir = os.path.dirname(self.view.file_name())
             r = subprocess.Popen(goimports_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, shell=True,
-                                 stderr=subprocess.PIPE).communicate(input=buf)
+                                 cwd=cur_dir, stderr=subprocess.PIPE).communicate(input=buf)
 
             if len(r[1]) != 0:
                 raise GoImportsException(r[1])

--- a/README.md
+++ b/README.md
@@ -46,15 +46,6 @@ from `Tools > GoImports` menu in Sublime Text 3.
 Limitations/Issues
 -
 Since this plugin uses [goimports](http://github.com/bradfitz/goimports "goimports repository"), it will be inherently limited to that tool's issues.
-One main issue I encountered was when the 3-rd party package name did not match its folder name.
-
-In this case [goimports](http://github.com/bradfitz/goimports "goimports repository") removes the package import. To fix this, import the packages like so (named package)
-
-```go
-import(
-Alfred "bitbucket.org/listboss/go-alfred"
-)
-```
 
 TODO
 -


### PR DESCRIPTION
they used to disappear, now they dont.

fixed by passing the current directory of the file being edited to goimports.